### PR TITLE
Add text color and background color pickers, using an existing component

### DIFF
--- a/js/src/block/components/edit.js
+++ b/js/src/block/components/edit.js
@@ -4,39 +4,71 @@
 import classnames from 'classnames';
 
 /**
- * Internal dependencies
- */
-/**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { ContrastChecker, PanelColorSettings, InspectorControls, RichText } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
 import { BLOCK_CLASS } from '../constants';
 
 /**
  * The Edit component for the block.
  */
-const Edit = ( { attributes: { className, option1, option2, question }, setAttributes } ) => {
+const Edit = ( { attributes: { backgroundColor, className, option1, option2, textColor, question }, setAttributes } ) => {
+	const style = { backgroundColor, color: textColor };
+
 	return (
-		<div className={ classnames( BLOCK_CLASS, className ) }>
-			<RichText
-				placeholder={ __( 'Survey question', 'easy-survey' ) }
-				value={ question }
-				onChange={ ( newValue ) => setAttributes( { question: newValue } ) }
-			/>
-			<RichText
-				placeholder={ __( 'First option', 'easy-survey' ) }
-				value={ option1 }
-				onChange={ ( newValue ) => setAttributes( { option1: newValue } ) }
-				className="wp-block-button__link"
-			/>
-			<RichText
-				placeholder={ __( 'Second option', 'easy-survey' ) }
-				value={ option2 }
-				onChange={ ( newValue ) => setAttributes( { option2: newValue } ) }
-				className="wp-block-button__link"
-			/>
-		</div>
+		<>
+			<InspectorControls>
+				<PanelColorSettings
+					title={ __( 'Color settings', 'easy-survey' ) }
+					colorSettings={ [
+						{
+							value: textColor,
+							onChange: ( newValue ) => setAttributes( { textColor: newValue } ),
+							label: __( 'Text color', 'easy-survey' ),
+						},
+						{
+							value: backgroundColor,
+							onChange: ( newValue ) => setAttributes( { backgroundColor: newValue } ),
+							label: __( 'Background color', 'easy-survey' ),
+						},
+					] }
+				>
+					<ContrastChecker
+						{ ...{
+							textColor,
+							backgroundColor,
+						} }
+						isLargeText={ false }
+					/>
+				</PanelColorSettings>
+			</InspectorControls>
+			<div className={ classnames( BLOCK_CLASS, className ) }>
+				<RichText
+					placeholder={ __( 'Survey question', 'easy-survey' ) }
+					value={ question }
+					onChange={ ( newValue ) => setAttributes( { question: newValue } ) }
+				/>
+				<RichText
+					placeholder={ __( 'First option', 'easy-survey' ) }
+					value={ option1 }
+					onChange={ ( newValue ) => setAttributes( { option1: newValue } ) }
+					className="wp-block-button__link"
+					style={ style }
+				/>
+				<RichText
+					placeholder={ __( 'Second option', 'easy-survey' ) }
+					value={ option2 }
+					onChange={ ( newValue ) => setAttributes( { option2: newValue } ) }
+					className="wp-block-button__link"
+					style={ style }
+				/>
+			</div>
+		</>
 	);
 };
 

--- a/js/src/block/index.js
+++ b/js/src/block/index.js
@@ -24,6 +24,9 @@ export default registerBlockType(
 			__( 'Survey', 'easy-survey' ),
 		],
 		attributes: {
+			backgroundColor: {
+				type: 'string',
+			},
 			className: {
 				type: 'boolean',
 			},
@@ -31,6 +34,9 @@ export default registerBlockType(
 				type: 'string',
 			},
 			option2: {
+				type: 'string',
+			},
+			textColor: {
 				type: 'string',
 			},
 			question: {


### PR DESCRIPTION
Adds `color` and `background-color` pickers, using a component:

![color-backgroudn-ds](https://user-images.githubusercontent.com/4063887/80334263-52ead080-8816-11ea-8956-01f8454d8766.png)
